### PR TITLE
Pin to Wasmtime 8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,12 +38,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
-name = "arbitrary"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
-
-[[package]]
 name = "async-trait"
 version = "0.1.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,22 +131,23 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.96.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git#7b5819b55a1383e969e468825a817e397777bcc6"
+version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9fb5af44f8cb4685d425a5101f562800618cfe7a454e23f87710ebfb22af50"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.96.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git#7b5819b55a1383e969e468825a817e397777bcc6"
+version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b50041c01a29ab8c2dd93188a024d67c30a099067aa45bcb0f2bb0f6701b003"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
- "cranelift-control",
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
@@ -165,37 +160,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.96.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git#7b5819b55a1383e969e468825a817e397777bcc6"
+version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cdc8a18f16dff6690dc1a0ff5e3319b84904e6e9af06056e4712c3dca4ee63b"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.96.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git#7b5819b55a1383e969e468825a817e397777bcc6"
-
-[[package]]
-name = "cranelift-control"
-version = "0.96.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git#7b5819b55a1383e969e468825a817e397777bcc6"
-dependencies = [
- "arbitrary",
-]
+version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420bc3bed85c6879e0383318c0a614c00f2a74df67c37b7ab4cfd0c19fe11794"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.96.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git#7b5819b55a1383e969e468825a817e397777bcc6"
+version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6319b1918ca95faef80f17a44b5394bb63facd899f5369a54fbcc23e67971a"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.96.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git#7b5819b55a1383e969e468825a817e397777bcc6"
+version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a626e2d07bec4d029ba0393547433bc1cd6f1335581dd833f06e3feb3cbaf72a"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -205,13 +196,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.96.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git#7b5819b55a1383e969e468825a817e397777bcc6"
+version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af8d1e5435264cac8208e34cc550abf6797ad6c7b4f6c874dc93a8249aa7d35"
 
 [[package]]
 name = "cranelift-native"
-version = "0.96.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git#7b5819b55a1383e969e468825a817e397777bcc6"
+version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "789bc52610128a42bbbba8e9b309eb73f8622bf10f55eb632ef552162a723ca7"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -220,8 +213,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.96.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git#7b5819b55a1383e969e468825a817e397777bcc6"
+version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dbb9a85d3e0371fc65085dfde86211305a562c70bae9ea0a57155f58750983"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1101,8 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "9.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git#7b5819b55a1383e969e468825a817e397777bcc6"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a65e578b6d35f3e808b21b00c652b4c3ded90249f642d504a67700d7a02cac1c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1132,16 +1127,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "9.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git#7b5819b55a1383e969e468825a817e397777bcc6"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdaba4716347d5936234f17d1c75a3a92f21edaefc96dbdc64b36ef53504c1e1"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "9.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git#7b5819b55a1383e969e468825a817e397777bcc6"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673200e1afd89735b9e641ec63218e9b7edf2860257db1968507c0538511d612"
 dependencies = [
  "anyhow",
  "base64",
@@ -1159,8 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "9.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git#7b5819b55a1383e969e468825a817e397777bcc6"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e83eb45f3bab16800cb9da977b04cd427f3e2b1e6668b6c2dcbc8baec8a6b6d"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -1173,17 +1171,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "9.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git#7b5819b55a1383e969e468825a817e397777bcc6"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e9c89418c99fed44b9081e09ec4a9c5a3843ad663c4b0beceb16cac7a70c31d"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "9.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git#7b5819b55a1383e969e468825a817e397777bcc6"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed4490e68a86a8515071c19bd54a679b5c239c43badd24c18c764a63117ba119"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
- "cranelift-control",
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-native",
@@ -1200,12 +1199,12 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift-shared"
-version = "9.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git#7b5819b55a1383e969e468825a817e397777bcc6"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73493000ea57cc755b4ab48df9194740c00ea6dcd2714b660b7859a451c1b925"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
- "cranelift-control",
  "cranelift-native",
  "gimli",
  "object",
@@ -1215,8 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "9.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git#7b5819b55a1383e969e468825a817e397777bcc6"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2a2c8dcf2c4bacaa5bd29fbbc744769804377747940c6d5fe12b15bdfafe2c"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -1233,8 +1233,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "9.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git#7b5819b55a1383e969e468825a817e397777bcc6"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bcc711e6ccb9314b4d90112912060539ce98ac43b4d4408680609414de004f"
 dependencies = [
  "cc",
  "cfg-if",
@@ -1245,8 +1246,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "9.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git#7b5819b55a1383e969e468825a817e397777bcc6"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b75238696641fb46dcf3cd6aaf09ac4c48040c5e2391d5c5a9883c35b09a627"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -1269,8 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "9.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git#7b5819b55a1383e969e468825a817e397777bcc6"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47cc7e383300218d338fcbe95f2d7343e125b6b0d284d0d9b7e6acc7dd112a1"
 dependencies = [
  "object",
  "once_cell",
@@ -1279,8 +1282,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "9.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git#7b5819b55a1383e969e468825a817e397777bcc6"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c1b25e736692815a53f669e774e230b80ec063f21596f006f8310b9f2dd910"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1289,8 +1293,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "9.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git#7b5819b55a1383e969e468825a817e397777bcc6"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a305b2e4e62dfc67c8d25b2db1c2ac6ba44c7bcf0ccefb7fd9205338bed3f6a"
 dependencies = [
  "anyhow",
  "cc",
@@ -1313,8 +1318,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "9.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git#7b5819b55a1383e969e468825a817e397777bcc6"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efecff824b08f5c1da332a776ce01a928b200b27dbbb3ffd9374d7f2718671ea"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -1324,8 +1330,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "9.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git#7b5819b55a1383e969e468825a817e397777bcc6"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796fdb0983ac1b3da4509169f49eea5e902b5641324466dc6f158c6e4ea693f5"
 dependencies = [
  "anyhow",
  "heck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ libc = "0.2.140"
 nix = { version = "0.26", default-features = false, features = ["signal"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-wasmtime = { git = "https://github.com/bytecodealliance/wasmtime.git" }
+wasmtime = { version = "8.0.0" }


### PR DESCRIPTION
Building off the main branch fails, let's use Wasmtime v8 now that it's out.