### PR TITLE
Return the lambda's return value

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -73,7 +73,7 @@ fn main() {
     let mut store = Store::new(&engine, ());
     store.add_fuel(100000000000).unwrap();
 
-    let (_, res) = wasmprof(100, engine, &mut store, wasmprof::WeightUnit::Fuel, |store| {
+    let (_, res, _) = wasmprof(100, engine, &mut store, wasmprof::WeightUnit::Fuel, |store| {
         let instance = Instance::new(store.as_context_mut(), &module, &[]).unwrap();
         let func = instance
             .get_typed_func::<i32, i32>(store.as_context_mut(), "fib")

--- a/src/bin/wasmprof.rs
+++ b/src/bin/wasmprof.rs
@@ -22,7 +22,7 @@ fn main() {
     let func = instance
             .get_typed_func::<i64, i64>(store.as_context_mut(), "fib")
             .unwrap();
-    let (_, res) = wasmprof(100, engine, &mut store, wasmprof::WeightUnit::Nanoseconds,|mut store| {
+    let (_, res, _) = wasmprof(100, engine, &mut store, wasmprof::WeightUnit::Nanoseconds,|mut store| {
         for _ in 0..10 {
             func.call(&mut store, 40).unwrap();
         }


### PR DESCRIPTION
Makes it nicer, when integrating with function-runner I had to use a `let result : Option<T> = None`, assign in the lambda, and then unwrap after.