### PR TITLE
Use the store's engine over an arg

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -73,9 +73,8 @@ fn main() {
     let mut store = Store::new(&engine, ());
     store.add_fuel(100000000000).unwrap();
 
-    let (_, res, _) = wasmprof(
+    let (res, _) = wasmprof(
         100,
-        engine,
         &mut store,
         wasmprof::WeightUnit::Fuel,
         |store| {

--- a/src/bin/wasmprof.rs
+++ b/src/bin/wasmprof.rs
@@ -22,9 +22,8 @@ fn main() {
     let func = instance
         .get_typed_func::<i64, i64>(store.as_context_mut(), "fib")
         .unwrap();
-    let (_, res, _) = wasmprof(
+    let (res, _) = wasmprof(
         100,
-        engine,
         &mut store,
         wasmprof::WeightUnit::Nanoseconds,
         |mut store| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,11 +87,10 @@ pub enum WeightUnit {
 
 pub fn wasmprof<T, FnReturn>(
     frequency: c_int,
-    engine: wasmtime::Engine,
     store: &mut wasmtime::Store<T>,
     weight_unit: WeightUnit,
     f: impl FnOnce(&mut Store<T>) -> FnReturn,
-) -> (wasmtime::Engine, profile_data::ProfileData, FnReturn) {
+) -> (profile_data::ProfileData, FnReturn) {
     register_signal_handler().unwrap();
     unsafe {
         TIMER = Some(timer::Timer::new(frequency));
@@ -112,7 +111,7 @@ pub fn wasmprof<T, FnReturn>(
         Ok(1)
     });
 
-    unsafe { ENGINE = Some(engine) };
+    unsafe { ENGINE = Some(store.engine().clone()) };
 
     let fn_return = f(store);
 
@@ -147,8 +146,9 @@ pub fn wasmprof<T, FnReturn>(
         samples.push(sample);
     }
 
+    unsafe { ENGINE.take() };
+
     (
-        unsafe { ENGINE.take().unwrap() },
         profile_data::ProfileData::new(frames, samples, Some(weights)),
         fn_return,
     )


### PR DESCRIPTION
The store itself is cheap to clone. By making a new clone, we remove the need for moving the engine in and out.