### PR TITLE
fix(wasm): syntax update

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -13,26 +13,27 @@ fn main() {
             (export "fib" (func $fib))
             (func $fib (param $n i32) (result i32)
              (if
+              (result i32)
               (i32.lt_s
-               (get_local $n)
+               (local.get $n)
                (i32.const 2)
               )
-              (return
+              (then
                (i32.const 1)
               )
-             )
-             (return
-              (i32.add
-               (call $fib
-                (i32.sub
-                 (get_local $n)
-                 (i32.const 2)
+              (else
+               (i32.add
+                (call $fib
+                 (i32.sub
+                  (local.get $n)
+                  (i32.const 2)
+                 )
                 )
-               )
-               (call $fib2
-                (i32.sub
-                 (get_local $n)
-                 (i32.const 1)
+                (call $fib2
+                 (i32.sub
+                  (local.get $n)
+                  (i32.const 1)
+                 )
                 )
                )
               )
@@ -40,26 +41,27 @@ fn main() {
             )
             (func $fib2 (param $n i32) (result i32)
              (if
+              (result i32)
               (i32.lt_s
-               (get_local $n)
+               (local.get $n)
                (i32.const 2)
               )
-              (return
+              (then
                (i32.const 1)
               )
-             )
-             (return
-              (i32.add
-               (call $fib2
-                (i32.sub
-                 (get_local $n)
-                 (i32.const 2)
+              (else
+               (i32.add
+                (call $fib2
+                 (i32.sub
+                  (local.get $n)
+                  (i32.const 2)
+                 )
                 )
-               )
-               (call $fib
-                (i32.sub
-                 (get_local $n)
-                 (i32.const 1)
+                (call $fib
+                 (i32.sub
+                  (local.get $n)
+                  (i32.const 1)
+                 )
                 )
                )
               )


### PR DESCRIPTION
Whenver I cloned the repo, because of the loose locking of deps, I have some newer lock that does not work. I am very new to rust and wasm. This PR made it work for me.
<img width="1417" alt="image" src="https://github.com/user-attachments/assets/66dd8f7b-1d28-4b3a-8e62-e0fd8595a46e">

Something about needing `then` and `else` for `if` statements, `get_local` has become `local.get` and some i32 nonsense. Feel free to close if I was supposed to run differently than:
```sh
cargo run --example basic
```