### PR TITLE
bump wasmtime to v31 and bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "wasmprof"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "cpp_demangle",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmprof"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "MIT"
 description = "wasmprof allows to profile code running inside of wasmtime"


### PR DESCRIPTION
use v31 as opposed to v32 as it is the latest version with `deterministic-wasi-ctx` support